### PR TITLE
Refactor UavcanSerializationRulesGenerator for easier DI

### DIFF
--- a/RevolveUavcan/Dsdl/DsdlParser.cs
+++ b/RevolveUavcan/Dsdl/DsdlParser.cs
@@ -10,9 +10,9 @@ using Attribute = RevolveUavcan.Dsdl.Fields.Attribute;
 
 namespace RevolveUavcan.Dsdl
 {
-    public class DsdlParser
+    public class DsdlParser : IDsdlParser
     {
-        public Dictionary<string, CompoundType> ParsedDsdlDict = new Dictionary<string, CompoundType>();
+        public Dictionary<string, CompoundType> ParsedDsdlDict { get; private set; } = new Dictionary<string, CompoundType>();
 
         /// <summary>
         /// Where the DSDL files to parse are located, defaults to the standard

--- a/RevolveUavcan/Dsdl/IDsdlParser.cs
+++ b/RevolveUavcan/Dsdl/IDsdlParser.cs
@@ -7,11 +7,10 @@ namespace RevolveUavcan.Dsdl
 {
     public interface IDsdlParser
     {
-        public Dictionary<string, CompoundType> ParsedDsdlDict { get; }
-        public string DsdlPath { get; set; }
+        Dictionary<string, CompoundType> ParsedDsdlDict { get; }
+        string DsdlPath { get; set; }
 
-        public Dictionary<string, CompoundType> ParseAllDirectories();
-
-        public CompoundType ParseSource(string filename, string sourceText);
+        Dictionary<string, CompoundType> ParseAllDirectories();
+        CompoundType ParseSource(string filename, string sourceText);
     }
 }

--- a/RevolveUavcan/Dsdl/IDsdlParser.cs
+++ b/RevolveUavcan/Dsdl/IDsdlParser.cs
@@ -1,0 +1,17 @@
+﻿using RevolveUavcan.Dsdl.Types;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RevolveUavcan.Dsdl
+{
+    public interface IDsdlParser
+    {
+        public Dictionary<string, CompoundType> ParsedDsdlDict { get; }
+        public string DsdlPath { get; set; }
+
+        public Dictionary<string, CompoundType> ParseAllDirectories();
+
+        public CompoundType ParseSource(string filename, string sourceText);
+    }
+}

--- a/RevolveUavcan/Uavcan/UavcanSerializationRulesGenerator.cs
+++ b/RevolveUavcan/Uavcan/UavcanSerializationRulesGenerator.cs
@@ -17,10 +17,10 @@ namespace RevolveUavcan.Uavcan
         public Dictionary<Tuple<uint, string>, UavcanService> ServiceSerializationRules { get; private set; }
 
         private Dictionary<string, CompoundType> _parsedDsdl;
-
-        public UavcanSerializationRulesGenerator(Dictionary<string, CompoundType> parsedDsdl)
+        private IDsdlParser _dsdlParser;
+        public UavcanSerializationRulesGenerator(IDsdlParser dsdlParser)
         {
-            _parsedDsdl = parsedDsdl;
+            _dsdlParser = dsdlParser;
 
             MessageSerializationRules = new Dictionary<Tuple<uint, string>, List<UavcanChannel>>();
             ServiceSerializationRules = new Dictionary<Tuple<uint, string>, UavcanService>();
@@ -30,6 +30,7 @@ namespace RevolveUavcan.Uavcan
         {
             try
             {
+                _parsedDsdl = _dsdlParser.ParseAllDirectories();
                 GenerateSerializationRulesForAllDsdl();
                 return true;
             }

--- a/RevolveUavcanTest/Uavcan/UavcanSerializationRulesGeneratorTests.cs
+++ b/RevolveUavcanTest/Uavcan/UavcanSerializationRulesGeneratorTests.cs
@@ -4,6 +4,7 @@ using RevolveUavcan.Dsdl.Types;
 using RevolveUavcan.Uavcan;
 using System.IO;
 using RevolveUavcan.Dsdl.Fields;
+using RevolveUavcan.Dsdl;
 
 namespace RevolveUavcanTest.Uavcan
 {
@@ -15,7 +16,9 @@ namespace RevolveUavcanTest.Uavcan
         [DeploymentItem("60.cinco.1.0.uavcan", "TestFiles/TestDsdl/common")]
         public void GenerateSingleMessageSerializationRule(Dictionary<string, CompoundType> dsdlDict, uint expectedSubjectId, string expectedMessageName, List<UavcanChannel> expectedSerializationRule)
         {
-            var rulesGenerator = new UavcanSerializationRulesGenerator(dsdlDict);
+            var dsdlParser = new Moq.Mock<IDsdlParser>();
+            dsdlParser.Setup(d => d.ParseAllDirectories()).Returns(dsdlDict);
+            var rulesGenerator = new UavcanSerializationRulesGenerator(dsdlParser.Object);
             Assert.IsTrue(rulesGenerator.Init());
 
             Assert.IsTrue(rulesGenerator.TryGetSerializationRuleForMessage(expectedSubjectId, out var idRules));

--- a/RevolveUavcanTest/Uavcan/UavcanSerializationRulesGeneratorTests.cs
+++ b/RevolveUavcanTest/Uavcan/UavcanSerializationRulesGeneratorTests.cs
@@ -128,7 +128,9 @@ namespace RevolveUavcanTest.Uavcan
         [DynamicData(nameof(GetDsdlAndResultForService), DynamicDataSourceType.Method)]
         public void GenerateSingleServiceSerializationRule(Dictionary<string, CompoundType> dsdlDict, uint expectedSubjectId, string expectedServiceName, List<UavcanChannel> expectedRequestSerializationRule, List<UavcanChannel> expectedResponseSerializationRule)
         {
-            var rulesGenerator = new UavcanSerializationRulesGenerator(dsdlDict);
+            var dsdlParser = new Moq.Mock<IDsdlParser>();
+            dsdlParser.Setup(d => d.ParseAllDirectories()).Returns(dsdlDict);
+            var rulesGenerator = new UavcanSerializationRulesGenerator(dsdlParser.Object);
             Assert.IsTrue(rulesGenerator.Init());
 
             Assert.IsTrue(rulesGenerator.TryGetSerializationRuleForService(expectedSubjectId, out var idRules));


### PR DESCRIPTION
Adds IDsdlParser interface and makes it possible to inject the rule generator.

Resolves #11 