### PR TITLE
Clear dictionaries before initializing rules

### DIFF
--- a/RevolveUavcan/Uavcan/UavcanSerializationRulesGenerator.cs
+++ b/RevolveUavcan/Uavcan/UavcanSerializationRulesGenerator.cs
@@ -28,6 +28,8 @@ namespace RevolveUavcan.Uavcan
             try
             {
                 DsdlParser.ParseAllDirectories();
+                MessageSerializationRules.Clear();
+                ServiceSerializationRules.Clear();
                 GenerateSerializationRulesForAllDsdl();
             }
             catch (DsdlException e)


### PR DESCRIPTION
This avoid a crash if Init() is called multiple times