### PR TITLE
Removed the accidentaly added non-working ulong implementation

### DIFF
--- a/RevolveUavcan/Tools/BitArrayTools.cs
+++ b/RevolveUavcan/Tools/BitArrayTools.cs
@@ -115,27 +115,6 @@ namespace RevolveUavcan.Tools
         }
 
         /// <summary>
-        /// Calculate the ulong value of a BitArray
-        /// </summary>
-        /// <param name="bitArray">The BitArray we want to calculate the corresponding ulong value for</param>
-        /// <returns>An integer representation of the BitArray</returns>
-        public static ulong GetULongFromBitArray(this BitArray bitArray)
-        {
-            if (bitArray.Length > 64)
-            {
-                throw new ArgumentException("BitArray length cannot be greater than 64 bits.");
-            }
-
-            // Initialize bitArrayWithMsb with values from bitArray and fill it with MSB
-            BitArray bitArrayWithMsb = FillBitArrayWithMSB(bitArray, 64);
-
-            // Find and return corresponding integer value from bitArrayWithMsb
-            int[] array = new int[2];
-            bitArrayWithMsb.CopyTo(array, 0);
-            return (uint)array[0] + ((ulong)(uint)array[1] << 32);
-        }
-
-        /// <summary>
         /// Calculate the long value of a BitArray
         /// </summary>
         /// <param name="bitArray">The BitArray we want to calculate the corresponding long value for</param>

--- a/RevolveUavcanTest/Tools/BitArrayToolsGetValueTests.cs
+++ b/RevolveUavcanTest/Tools/BitArrayToolsGetValueTests.cs
@@ -148,35 +148,5 @@ namespace RevolveUavcanTest.Tools
             yield return new object[] { new BitArray(42) };
             yield return new object[] { new BitArray(69) };
         }
-
-
-        [DataTestMethod]
-        [DynamicData(nameof(GetULongValidData), DynamicDataSourceType.Method)]
-        public void GetULongValidArgsTest(BitArray bitArray, ulong expectedResult)
-        {
-            var result = bitArray.GetULongFromBitArray();
-            Assert.AreEqual(expectedResult, result);
-        }
-
-        public static IEnumerable<object[]> GetULongValidData()
-        {
-            yield return new object[] { new BitArray(BitConverter.GetBytes((ulong) 12)), (ulong) 12 };
-            yield return new object[] { new BitArray(BitConverter.GetBytes((ulong) 17)), (ulong ) 17 };
-            yield return new object[] { new BitArray(BitConverter.GetBytes((ulong) 128)), (ulong) 128 };
-            yield return new object[] { new BitArray(BitConverter.GetBytes((ulong) 12_000)), (ulong) 12_000 };
-            yield return new object[] { new BitArray(BitConverter.GetBytes((ulong) 3_000_000_000)), (ulong) 3_000_000_000 };
-        }
-
-        [TestMethod]
-        [DynamicData(nameof(GetULongInvalidData), DynamicDataSourceType.Method)]
-        public void GetULongInvalidArgsTest(BitArray bitArray)
-        {
-            Assert.ThrowsException<ArgumentException>(() => bitArray.GetULongFromBitArray());
-        }
-
-        public static IEnumerable<object[]> GetULongInvalidData()
-        {
-            yield return new object[] { new BitArray(69) };
-        }
     }
 }


### PR DESCRIPTION
Closes #37 

Remove the ULong implementation not working.
As discussed in #37, it is not needed.

As shown in the image below, the function is only referenced in the tests, and thus removing it and the tests should be sufficient.

![image](https://github.com/RevolveNTNU/RevolveUavcan/assets/22020993/fb51c2f8-d794-4c95-98b9-6fcb3d8039b5)
